### PR TITLE
INFRA-1461: Add 'process_body' option.

### DIFF
--- a/lib/resty/waf.lua
+++ b/lib/resty/waf.lua
@@ -608,6 +608,7 @@ function _M.new()
 		_mode                        = 'SIMULATE',
 		_nameservers                 = {},
 		_pcre_flags                  = 'oij',
+		_process_body                = true,
 		_process_multipart_body      = true,
 		_req_tid_header              = false,
 		_res_body_max_size           = (1024 * 1024),

--- a/lib/resty/waf/request.lua
+++ b/lib/resty/waf/request.lua
@@ -13,6 +13,11 @@ local table_insert = table.insert
 _M.version = base.version
 
 function _M.parse_request_body(waf, request_headers, collections)
+    if not waf._process_body then
+        --_LOG_"process_body option disabled, ignoring the body"
+        return nil
+    end
+
 	local content_type_header = request_headers["content-type"]
 
 	-- multiple content-type headers are likely an evasion tactic


### PR DESCRIPTION
When set to `false`, this option disables parsing of the request body.

We don't use any rules that require the body so this should alleviate the performance problems the waf has when attempting to parse it.
